### PR TITLE
add instructions for installing dependencies on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ This repo contains a generic (C++, python) linter and auto formatter package tha
 ## Dependencies
 
  * **autopep8** ([Introduction to autopep8](http://avilpage.com/2015/05/automatically-pep8-your-python-code.html))
-   * Ubuntu 14.04: `pip install autopep8`
+   * Ubuntu 14.04 / macOS: `pip install autopep8`
  * **clang-format**
    * Ubuntu 14.04: `sudo apt-get install clang-format-3.X`
+   * macOS: 
+     ```
+     brew install clang-format
+     ln -s /usr/local/share/clang/clang-format-diff.py /usr/local/bin/clang-format-diff-3.8
+     ```
 
 
 ## Installation


### PR DESCRIPTION
The clang-format-diff script provided by Homebrew is not in PATH by default. Thus I linked it manually to /usr/local/bin and changed the name to "clang-format-diff-3.8", as expected by the pre-commit hook.