### PR TITLE
fix header guard linter

### DIFF
--- a/init-git-hooks.py
+++ b/init-git-hooks.py
@@ -26,7 +26,7 @@ import shutil
 import subprocess
 import sys
 
-default_cpplint = "old_cpplint.py"
+default_cpplint = "modified_old_cpplint.py"
 
 cpplint_url = ""
 pylint_url = "https://raw.githubusercontent.com/vinitkumar/googlecl/6dc04b489dba709c53d2f4944473709617506589/googlecl-pylint.rc"

--- a/pre-commit
+++ b/pre-commit
@@ -67,7 +67,7 @@ def get_unstaged_files(some_folder_in_root_repo='./'):
   return output.split("\n")
 
 
-def check_cpp_lint(staged_files, cpplint_file, ascii_art):
+def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
   """Runs Google's cpplint on all C++ files staged for commit,"""
   cpplint = imp.load_source('cpplint', cpplint_file)
   cpplint._cpplint_state.SetFilters('-legal/copyright')  # pylint: disable=W0212
@@ -85,7 +85,7 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art):
       package_root = ''
       search_dir = os.path.dirname(changed_file)
       found_package_root = False
-      for _ in range(1, 10):
+      for _ in range(1, 20):
         if os.path.isfile(search_dir + '/package.xml'):
           package_root = search_dir
           found_package_root = True
@@ -344,7 +344,8 @@ def main():
     run_autopep8_format(repo_root, staged_files, list_of_changed_staged_files)
 
     # Use Google's C++ linter to check for compliance with Google style guide.
-    cpp_lint_success = check_cpp_lint(staged_files, cpplint_file, ascii_art)
+    cpp_lint_success = check_cpp_lint(
+        staged_files, cpplint_file, ascii_art, repo_root)
 
     # Use pylint to check for comimpliance with Tensofrflow python style guide.
     pylint_success = check_python_lint(repo_root, staged_files, pylint_file)

--- a/pre-commit
+++ b/pre-commit
@@ -85,7 +85,8 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
       package_root = ''
       search_dir = os.path.dirname(changed_file)
       found_package_root = False
-      for _ in range(1, 20):
+      MAX_DEPTH_OF_FILES = 100
+      for _ in range(1, MAX_DEPTH_OF_FILES):
         if os.path.isfile(search_dir + '/package.xml'):
           package_root = search_dir
           found_package_root = True


### PR DESCRIPTION
I had to partially upgrade to the new cpplint file to get the header guards right, at least for layered include folders such as `include/voxblox/core/stuff.h`