### PR TITLE
Possibility to install linter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(linter)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple(ALL_DEPS_REQUIRED)
+
+cs_install()
+cs_export()

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
 
 ## Installation
 
+### Installation via submodule
+This requires the linter to be a submodule of the repository that should be checked.
+
 ```bash
 cd $YOUR_REPO
 git submodule add git@github.com:ethz-asl/linter.git
@@ -42,6 +45,18 @@ git submodule add git@github.com:ethz-asl/linter.git dev_tools/linter
 ./dev_tools/linter/init-git-hooks.py
 ```
 
+### Installation via catkin
+If ROS/Catkin is available, the linter can also be installed and the same linter version can be used from multiple repositories.
+```bash
+export CATKIN_WS="~/catkin_ws"
+cd $CATKIN_WS/src
+git clone git@github.com:ethz-asl/linter.git
+catkin build linter
+source $CATKIN_WS/devel/setup.bash
+rosrun linter init-git-hooks.py
+```
+
+### Configuration
 Define the project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example:
 
 ```

--- a/git-hooks.py
+++ b/git-hooks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import subprocess
 import sys
 
@@ -22,10 +23,23 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
                                  some_folder_in_root_repo)
 
 
-def get_linter_subfolder(root_repo_folder):
-    """Find the subfolder where this linter is stored."""
-    return run_command_in_folder("git submodule | awk '{ print $2 }'" +
-                                 " | grep linter", root_repo_folder)
+def get_linter_folder(root_repo_folder):
+    """Find the folder where this linter is stored."""
+    linter_subfolder = run_command_in_folder(
+        "git submodule | awk '{ print $2 }'" + " | grep linter",
+        root_repo_folder)
+    if len(linter_subfolder) != 0:
+        return os.path.join(repo_root_folder, linter_subfolder)
+
+    # Try catkin package.
+    linter_subfolder = run_command_in_folder("catkin_find linter | grep src",
+                                             root_repo_folder)
+    if len(linter_subfolder) != 0:
+        return linter_subfolder
+
+    raise Exception(
+        "Couldn't find linter folder: needs to be a submodule of the "
+        "current repository or an installed catkin package.")
 
 
 def main():
@@ -33,15 +47,14 @@ def main():
     repo_root = get_git_repo_root()
 
     # Get linter subfolder
-    linter_subfolder = get_linter_subfolder(repo_root)
+    linter_folder = get_linter_folder(repo_root)
 
     # Append linter folder to the path so that we can import the linter module.
-    linter_folder = repo_root + "/" + linter_subfolder
     sys.path.append(linter_folder)
 
     import linter
 
-    linter.linter_check(repo_root, linter_subfolder)
+    linter.linter_check(repo_root, linter_folder)
 
 
 if __name__ == "__main__":

--- a/git-hooks.py
+++ b/git-hooks.py
@@ -29,7 +29,7 @@ def get_linter_folder(root_repo_folder):
         "git submodule | awk '{ print $2 }'" + " | grep linter",
         root_repo_folder)
     if len(linter_subfolder) != 0:
-        return os.path.join(repo_root_folder, linter_subfolder)
+        return os.path.join(root_repo_folder, linter_subfolder)
 
     # Try catkin package.
     linter_subfolder = run_command_in_folder("catkin_find linter | grep src",

--- a/init-git-hooks.py
+++ b/init-git-hooks.py
@@ -52,6 +52,7 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
 
   stdout, _ = get_repo_call.communicate()
   repo_root = stdout.rstrip()
+  print 'repo root:', repo_root
   return repo_root
 
 
@@ -65,6 +66,7 @@ def main():
   """ Download cpplint.py and pylint.py and installs the git hooks"""
   script_directory = os.path.dirname(sys.argv[0])
   script_directory = os.path.abspath(script_directory)
+  print 'script dir:', script_directory
 
   if cpplint_url != "":
     # Download linter files.
@@ -93,7 +95,7 @@ def main():
     exit(1)
 
   # Get git root folder of parent repository.
-  repo_root = get_git_repo_root(script_directory + '/../')
+  repo_root = get_git_repo_root('.')
 
   # Copy git hooks.
   cp_params = script_directory + "/git-hooks.py " + \

--- a/init-git-hooks.py
+++ b/init-git-hooks.py
@@ -20,6 +20,8 @@ Set this variable to use the local modified copy of the newest cpplint script:
 default_cpplint = "cpplint.py"
 """
 
+from __future__ import print_function
+
 import os
 import requests
 import shutil
@@ -52,7 +54,6 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
 
   stdout, _ = get_repo_call.communicate()
   repo_root = stdout.rstrip()
-  print 'repo root:', repo_root
   return repo_root
 
 
@@ -66,7 +67,6 @@ def main():
   """ Download cpplint.py and pylint.py and installs the git hooks"""
   script_directory = os.path.dirname(sys.argv[0])
   script_directory = os.path.abspath(script_directory)
-  print 'script dir:', script_directory
 
   if cpplint_url != "":
     # Download linter files.

--- a/linter.py
+++ b/linter.py
@@ -346,12 +346,12 @@ def get_whitelisted_files(repo_root, files, whitelist):
   return whitelisted
 
 
-def linter_check(repo_root, linter_subfolder):
+def linter_check(repo_root, linter_folder):
   """ Main pre-commit function for calling code checking script. """
 
-  cpplint_file = repo_root + "/" + linter_subfolder + "/cpplint.py"
-  pylint_file = repo_root + "/" + linter_subfolder + "/pylint.rc"
-  ascii_art_file = repo_root + "/" + linter_subfolder + "/ascii_art.py"
+  cpplint_file =  linter_folder + "/cpplint.py"
+  pylint_file =  linter_folder + "/pylint.rc"
+  ascii_art_file =  linter_folder + "/ascii_art.py"
 
   # Read linter config file.
   linter_config_file = repo_root + '/linterconfig.yaml'
@@ -361,7 +361,7 @@ def linter_check(repo_root, linter_subfolder):
   else:
       linter_config = DEFAULT_CONFIG
 
-  print("Found linter subfolder: {}".format(linter_subfolder))
+  print("Found linter subfolder: {}".format(linter_folder))
   print("Found ascii art file at: {}".format(ascii_art_file))
   print("Found cpplint file at: {}".format(cpplint_file))
   print("Found pylint file at: {}".format(pylint_file))

--- a/linter.py
+++ b/linter.py
@@ -123,6 +123,13 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
                                   "catkin package that contains: "
                                   "{}".format(changed_file))
 
+      # Get relative path to repository root.
+      common_prefix = os.path.commonprefix([
+          os.path.abspath(repo_root), os.path.abspath(package_root)])
+      package_root = os.path.relpath(package_root, common_prefix)
+
+      # The package root needs to be relative to the repo root. Otherwise the
+      # header guard logic will fail!.
       cpplint._root = package_root + '/include'   # pylint: disable=W0212
 
       # Reset error count and messages:

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>linter</name>
+  <version>0.0.0</version>
+  <description>A linter for C++ and Python.</description>
+  <maintainer email="maplab-dev@mavt.ethz.ch">maplab-developers</maintainer>
+  <license>BSD-3</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+</package>


### PR DESCRIPTION
... via catkin packages. This allows only one linter repository to be reused in various other repositories. The old installation method via submodule is still supported.