### PR TITLE
Change python autoformatter to yapf and fix pylint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,18 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
    * **clang-format** Formats your code based on your .clang-format preferences.
    * **cpplint** Checks your C++ code for style errors and warnings.
    
- * **EXPERIMENTAL - Python** files:
+ * **Python** files:
 
-      **WARNING:** The default linter settings are very strict and might not actually conform with the formatting produced by autopep8. If you want to use this linter for python you will need to do some tweaking.
-      * **autopep8** Formats your python code.
+      * **yapf** Formats your python code.
       * **pylint** Checks your Python code for style errors and warnings.
      
 
 ## Dependencies
 
- * **autopep8** ([Introduction to autopep8](http://avilpage.com/2015/05/automatically-pep8-your-python-code.html))
-   * Ubuntu 14.04 / macOS: `pip install autopep8`
+ * **yapf**
+   * Ubuntu / macOS: `pip install yapf`
  * **clang-format**
-   * Ubuntu 14.04: `sudo apt-get install clang-format-3.X`
+   * Ubuntu: `sudo apt install clang-format-3.8`
    * macOS: 
      ```
      brew install clang-format

--- a/default/pylint.rc
+++ b/default/pylint.rc
@@ -1,0 +1,222 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add <file or directory> to the black list. It should be a base name, not a
+# path. You may set this option multiple times.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+extension-pkg-whitelist=numpy
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+disable=no-name-in-module,import-error,fixme
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (R0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching names used for dummy variables (i.e. not used).
+dummy-variables-rgx=_|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+# (Constant dectione is not very reliable, so also allow lower case letters.)
+const-rgx=(([A-Za-z_][A-Za-z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct function names
+# (Added upper case letters to match coordinate frames, e.g. T_G_I, v_M_I.)
+function-rgx=[a-z_][a-zA-Z0-9_]{2,50}$
+
+# Regular expression which should only match correct method names
+method-rgx=[a-zA-Z_][a-zA-Z0-9_]{0,50}$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,50}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-zA-Z_][a-zA-Z0-9_]{0,50}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-zA-Z_][a-zA-Z0-9_]{0,50}$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[a-zA-Z_][a-zA-Z0-9_]{0,50}$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Regular expression which should only match functions or classes name which do
+# not require a docstring
+no-docstring-rgx=__.*__
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed.
+generated-members=REQUEST,acl_users,aq_parent,numpy.uint32,numpy.float32
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp

--- a/init-git-hooks.py
+++ b/init-git-hooks.py
@@ -29,7 +29,6 @@ import sys
 default_cpplint = "modified_cpplint.py"
 
 cpplint_url = ""
-pylint_url = "https://raw.githubusercontent.com/vinitkumar/googlecl/6dc04b489dba709c53d2f4944473709617506589/googlecl-pylint.rc"
 
 clang_format_diff_executable = "clang-format-diff-3.8"
 
@@ -79,7 +78,16 @@ def main():
       print("Failed to copy default cpplint.")
       exit(1)
 
-  download_file_from_url(pylint_url, script_directory + "/pylint.rc")
+  default_pylint_file = os.path.join(script_directory, 'default', 'pylint.rc')
+  if not os.path.isfile(default_pylint_file):
+    print("Default pylint.rc wasn't found under", default_pylint_file)
+    exit(1)
+
+  cp_params = (default_pylint_file + " " + os.path.join(script_directory, 'pylint.rc'))
+  if subprocess.call("cp " + cp_params, shell=True) != 0:
+    print("Failed to copy default pylint.rc.")
+    exit(1)
+
   if not os.path.isfile(script_directory + "/pylint.rc"):
     print("ERROR: Could not download pylint.rc file!")
     exit(1)
@@ -88,8 +96,8 @@ def main():
     print("ERROR: " + clang_format_diff_executable + " is not installed!")
     exit(1)
 
-  if not command_exists("autopep8"):
-    print("ERROR: autopep8 is not installed! Try: pip install autopep8")
+  if not command_exists("yapf"):
+    print("ERROR: yapf is not installed! Try: pip install yapf")
     exit(1)
 
   # Get git root folder of parent repository.

--- a/linter.py
+++ b/linter.py
@@ -211,7 +211,7 @@ def run_clang_format(repo_root, staged_files, list_of_changed_staged_files):
 
   run_command_in_folder("git diff -U0 --cached | " +
                         CLANG_FORMAT_DIFF_EXECUTABLE +
-                        " -style=file -p1 > " +
+                        " --style=file -p1 > " +
                         clang_format_path, repo_root)
 
   if not os.stat(clang_format_path).st_size == 0:

--- a/linter.py
+++ b/linter.py
@@ -211,7 +211,7 @@ def run_clang_format(repo_root, staged_files, list_of_changed_staged_files):
 
   run_command_in_folder("git diff -U0 --cached | " +
                         CLANG_FORMAT_DIFF_EXECUTABLE +
-                        " --style=file -p1 > " +
+                        " -style=file -p1 > " +
                         clang_format_path, repo_root)
 
   if not os.stat(clang_format_path).st_size == 0:
@@ -248,7 +248,7 @@ def run_yapf_format(repo_root, staged_files, list_of_changed_staged_files):
                               os.path.basename(os.path.normpath(repo_root)) +
                               "_" + datetime.datetime.now().isoformat() +
                               ".yapf.patch")
-      task = (YAPF_FORMAT_EXECUTABLE + " -style google -d " + staged_file +
+      task = (YAPF_FORMAT_EXECUTABLE + " --style google -d " + staged_file +
               " > " + yapf_format_path)
       run_command_in_folder(task, repo_root)
 

--- a/linter.py
+++ b/linter.py
@@ -19,13 +19,13 @@ import subprocess
 import yaml
 
 CLANG_FORMAT_DIFF_EXECUTABLE = "clang-format-diff-3.8"
-AUTOPEP8_FORMAT_EXECUTABLE = "autopep8"
+YAPF_FORMAT_EXECUTABLE = "yapf"
 
 DEFAULT_CONFIG = {
   'use_clangformat':  True,
   'use_cpplint':      True,
   # Disable Python checks by default.
-  'use_autopep8':     False,
+  'use_yapf':         False,
   'use_pylint':       False,
   # Check all staged files by default.
   'whitelist':        []
@@ -43,8 +43,8 @@ def read_linter_config(filename):
     config['use_clangformat'] = parsed_config['clangformat']
   if 'cpplint' in parsed_config.keys():
     config['use_cpplint'] = parsed_config['cpplint']
-  if 'autopep8' in parsed_config.keys():
-    config['use_autopep8'] = parsed_config['autopep8']
+  if 'yapf' in parsed_config.keys():
+    config['use_yapf'] = parsed_config['yapf']
   if 'pylint' in parsed_config.keys():
     config['use_pylint'] = parsed_config['pylint']
   if 'whitelist' in parsed_config.keys():
@@ -233,8 +233,8 @@ def run_clang_format(repo_root, staged_files, list_of_changed_staged_files):
   return True
 
 
-def run_autopep8_format(repo_root, staged_files, list_of_changed_staged_files):
-  """Runs autopep8 format on all python files staged for commit."""
+def run_yapf_format(repo_root, staged_files, list_of_changed_staged_files):
+  """Runs yapf format on all python files staged for commit."""
 
   first_file_formatted = True
   for staged_file in staged_files:
@@ -244,17 +244,15 @@ def run_autopep8_format(repo_root, staged_files, list_of_changed_staged_files):
 
       # Check if the file needs formatting by applying the formatting and store
       # the results into a patch file.
-      autopep8_format_path = ("/tmp/" +
+      yapf_format_path = ("/tmp/" +
                               os.path.basename(os.path.normpath(repo_root)) +
                               "_" + datetime.datetime.now().isoformat() +
-                              ".autopep8.patch")
-      task = (AUTOPEP8_FORMAT_EXECUTABLE +
-              " -d --aggressive --aggressive --max-line-length=80 " +
-              "--indent-size=2 --ignore=E24 " +
-              staged_file + " > " + autopep8_format_path)
+                              ".yapf.patch")
+      task = (YAPF_FORMAT_EXECUTABLE + " -d " + staged_file +
+              " > " + yapf_format_path)
       run_command_in_folder(task, repo_root)
 
-      if not os.stat(autopep8_format_path).st_size == 0:
+      if not os.stat(yapf_format_path).st_size == 0:
         if first_file_formatted:
           print("=" * 80)
           print("Formatted staged python files with autopep8:")
@@ -270,7 +268,7 @@ def run_autopep8_format(repo_root, staged_files, list_of_changed_staged_files):
           exit(1)
         else:
           run_command_in_folder(
-              "git apply -p1 " + autopep8_format_path, repo_root)
+              "git apply -p0 " + yapf_format_path, repo_root)
           run_command_in_folder("git add " + staged_file, repo_root)
 
   if not first_file_formatted:
@@ -399,8 +397,8 @@ def linter_check(repo_root, linter_subfolder):
       run_clang_format(repo_root, whitelisted_files,
                        list_of_changed_staged_files)
 
-    if linter_config['use_autopep8']:
-      run_autopep8_format(repo_root, whitelisted_files,
+    if linter_config['use_yapf']:
+      run_yapf_format(repo_root, whitelisted_files,
                           list_of_changed_staged_files)
 
 

--- a/linter.py
+++ b/linter.py
@@ -25,8 +25,8 @@ DEFAULT_CONFIG = {
   'use_clangformat':  True,
   'use_cpplint':      True,
   # Disable Python checks by default.
-  'use_yapf':         False,
-  'use_pylint':       False,
+  'use_yapf':         True,
+  'use_pylint':       True,
   # Check all staged files by default.
   'whitelist':        []
 }

--- a/linter.py
+++ b/linter.py
@@ -248,7 +248,7 @@ def run_yapf_format(repo_root, staged_files, list_of_changed_staged_files):
                               os.path.basename(os.path.normpath(repo_root)) +
                               "_" + datetime.datetime.now().isoformat() +
                               ".yapf.patch")
-      task = (YAPF_FORMAT_EXECUTABLE + " -d " + staged_file +
+      task = (YAPF_FORMAT_EXECUTABLE + " -style google -d " + staged_file +
               " > " + yapf_format_path)
       run_command_in_folder(task, repo_root)
 

--- a/linterconfig.yaml_example
+++ b/linterconfig.yaml_example
@@ -1,8 +1,8 @@
 # Turn the components of the linter individualy on / off.
 clangformat: on
 cpplint: on
-autopep8: off
-pylint: off
+yapf: on
+pylint: on
 
 # If this whitelist block is present, the linter only operates on the files and
 # directories listed in this whitelist.


### PR DESCRIPTION
- Changes default python formatter to yapf and use google style for formatting
- Add custom pylint.rc based on the one we previously downloaded with some fixes:
  - Disable `no-name-in-module` and `import-error` warnings because these don't work with catkin python packages.
  - Disable `fixme` warnings to still allow `TODO` comments.
  - Allow lower case letters in constant variable names because pylint also declared variables as constant that aren't really const.
  - Allow upper case letters in function and non-const variable names to allow our coordinate frame notations (e.g. `T_M_I`, `v_G_M`).
- Turn on python autoformatting and linter by default.

Note that the default python style has significantly changed. Especially the indentation is now **4** instead of 2 spaces because [Google says so](https://google.github.io/styleguide/pyguide.html?showone=Indentation#Indentation). If you prefer to stay at 2-space indents, please try to persuade @hitzg and @Cianciu because they are strongly in favor of 4-space indents.

Also, it's not currently possible to change the python indent style on a per-repo basis because that would require changes in the yapf style (can be in the repo) and the pylint.rc (which is taken directly from linter folder).