### PR TITLE
Easier linter installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ init_linter_git_hooks --remove
 ```
 
 ## Linter configuration
-To configure the linter, a file named `linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
+To configure the linter, add a file named `linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
 
 Clang-format can be configured by defining a project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example file:
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
 ## Installation
 
 ```bash
-cd $YOUR_REPO
-git submodule add git@github.com:ethz-asl/linter.git
-./linter/init-git-hooks.py
+git clone git@github.com:ethz-asl/linter.git
+cd linter
+echo ". $(realpath setup_linter.sh)" >> ~/.bashrc  # Or the matching file for
+                                                   # your shell.
+source ~/.bashrc
 ```
 
-You can also add the linter submodule in a subfolder of your repo, e.g.:
+The you can install the linter in your repository:
 ```bash
-mkdir $YOUR_REPO/dev_tools
-git submodule add git@github.com:ethz-asl/linter.git dev_tools/linter
-./dev_tools/linter/init-git-hooks.py
+cd $YOUR_REPO
+init_linter_git_hooks
 ```
 
 Define the project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ echo ". $(realpath setup_linter.sh)" >> ~/.bashrc  # Or the matching file for
 source ~/.bashrc
 ```
 
-The you can install the linter in your repository:
+Then you can install the linter in your repository:
 ```bash
 cd $YOUR_REPO
 init_linter_git_hooks

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ init_linter_git_hooks --remove
 ```
 
 ## Linter configuration
-To configure the linter, add a file named `linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
+To configure the linter, add a file named `.linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
 
 Clang-format can be configured by defining a project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example file:
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
  * **C++** files:
    * **clang-format** Formats your code based on your .clang-format preferences.
    * **cpplint** Checks your C++ code for style errors and warnings.
-   
+
  * **Python** files:
 
       * **yapf** Formats your python code.
       * **pylint** Checks your Python code for style errors and warnings.
-     
+
 
 ## Dependencies
 
@@ -19,7 +19,7 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
    * Ubuntu / macOS: `pip install yapf`
  * **clang-format**
    * Ubuntu: `sudo apt install clang-format-3.8`
-   * macOS: 
+   * macOS:
      ```
      brew install clang-format
      ln -s /usr/local/share/clang/clang-format-diff.py /usr/local/bin/clang-format-diff-3.8
@@ -42,7 +42,17 @@ cd $YOUR_REPO
 init_linter_git_hooks
 ```
 
-Define the project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example:
+## Uninstallation
+To remove the linter from your git repository again, run the following:
+```bash
+cd $YOUR_REPO
+init_linter_git_hooks --remove
+```
+
+## Linter configuration
+To configure the linter, a file named `linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
+
+Clang-format can be configured by defining a project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example file:
 
 ```
 ---

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -54,7 +54,7 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
 
   stdout, _ = get_repo_call.communicate()
   repo_root = stdout.rstrip()
-  return repo_root, os.path.basename(repo_root)
+  return repo_root
 
 
 def command_exists(cmd):
@@ -104,12 +104,14 @@ def main():
     exit(1)
 
   # Get git root folder of parent repository.
-  repo_root, repo_folder_name = get_git_repo_root('.')
+  repo_root = get_git_repo_root('.')
   hooks_folder = os.path.join(repo_root, '.git/hooks')
   if os.path.isfile(os.path.join(repo_root, '.git')):
+    # Git repo is a submodule, git information is in a folder listed in the .git
+    # file.
     with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
       git_folder = yaml.load(git_info_file)['gitdir']
-    repo_root, _ = get_git_repo_root(os.path.join(repo_root, git_folder))
+    repo_root = get_git_repo_root(os.path.join(repo_root, git_folder))
     hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
 
   # Copy git hooks.

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -27,6 +27,7 @@ import requests
 import shutil
 import subprocess
 import sys
+import yaml
 
 default_cpplint = "modified_cpplint.py"
 
@@ -53,7 +54,7 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
 
   stdout, _ = get_repo_call.communicate()
   repo_root = stdout.rstrip()
-  return repo_root
+  return repo_root, os.path.basename(repo_root)
 
 
 def command_exists(cmd):
@@ -103,14 +104,20 @@ def main():
     exit(1)
 
   # Get git root folder of parent repository.
-  repo_root = get_git_repo_root('.')
+  repo_root, repo_folder_name = get_git_repo_root('.')
+  hooks_folder = os.path.join(repo_root, '.git/hooks')
+  if os.path.isfile(os.path.join(repo_root, '.git')):
+    with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
+      git_folder = yaml.load(git_info_file)['gitdir']
+    repo_root, _ = get_git_repo_root(os.path.join(repo_root, git_folder))
+    hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
 
   # Copy git hooks.
-  cp_params = script_directory + "/git-hooks.py " + \
-      repo_root + "/.git/hooks/pre-commit"
+  cp_params = script_directory + "/git_hooks.py " + \
+      hooks_folder + "/pre-commit"
   if subprocess.call("cp " + cp_params, shell=True) != 0:
     print("Failed to copy githooks to "
-          "{}...".format((repo_root + "/.git/hooks/")))
+          "{}...".format(hooks_folder))
     exit(1)
 
   print("Success, githooks initialized!")

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -135,7 +135,6 @@ def remove_linter():
   pre_commit_file = os.path.join(hooks_folder, 'pre-commit')
   with open(pre_commit_file, 'w+') as out_file:
     out_file.write('#!/bin/sh\n')
-  # subprocess.call('chmod +x'
   print("Linter githooks removed!")
 
 

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -22,6 +22,7 @@ default_cpplint = "cpplint.py"
 
 from __future__ import print_function
 
+import argparse
 import os
 import requests
 import shutil
@@ -63,7 +64,21 @@ def command_exists(cmd):
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
 
-def main():
+def get_hooks_folder_for_repo():
+  # Get git root folder of parent repository.
+  repo_root = get_git_repo_root('.')
+  hooks_folder = os.path.join(repo_root, '.git/hooks')
+  if os.path.isfile(os.path.join(repo_root, '.git')):
+    # Git repo is a submodule, git information is in a folder listed in the .git
+    # file.
+    with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
+      git_folder = yaml.load(git_info_file)['gitdir']
+    repo_root = get_git_repo_root(os.path.join(repo_root, git_folder))
+    hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
+  return hooks_folder
+
+
+def install_linter():
   """ Download cpplint.py and pylint.py and installs the git hooks"""
   script_directory = os.path.dirname(sys.argv[0])
   script_directory = os.path.dirname(os.path.abspath(script_directory))
@@ -103,18 +118,8 @@ def main():
     print("ERROR: yapf is not installed! Try: pip install yapf")
     exit(1)
 
-  # Get git root folder of parent repository.
-  repo_root = get_git_repo_root('.')
-  hooks_folder = os.path.join(repo_root, '.git/hooks')
-  if os.path.isfile(os.path.join(repo_root, '.git')):
-    # Git repo is a submodule, git information is in a folder listed in the .git
-    # file.
-    with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
-      git_folder = yaml.load(git_info_file)['gitdir']
-    repo_root = get_git_repo_root(os.path.join(repo_root, git_folder))
-    hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
-
   # Copy git hooks.
+  hooks_folder = get_hooks_folder_for_repo()
   cp_params = script_directory + "/git_hooks.py " + \
       hooks_folder + "/pre-commit"
   if subprocess.call("cp " + cp_params, shell=True) != 0:
@@ -123,6 +128,31 @@ def main():
     exit(1)
 
   print("Success, githooks initialized!")
+
+
+def remove_linter():
+  hooks_folder = get_hooks_folder_for_repo()
+  pre_commit_file = os.path.join(hooks_folder, 'pre-commit')
+  with open(pre_commit_file, 'w+') as out_file:
+    out_file.write('#!/bin/sh\n')
+  # subprocess.call('chmod +x'
+  print("Linter githooks removed!")
+
+
+def main():
+  arg_parser = argparse.ArgumentParser()
+  arg_parser.add_argument(
+      '--remove',
+      '-r',
+      dest='remove_linter',
+      action="store_true",
+      help='Remove the linter from this repository.')
+  args = arg_parser.parse_args()
+
+  if args.remove_linter:
+    remove_linter()
+  else:
+    install_linter()
 
 
 if __name__ == "__main__":

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -20,6 +20,8 @@ Set this variable to use the local modified copy of the newest cpplint script:
 default_cpplint = "cpplint.py"
 """
 
+from __future__ import print_function
+
 import os
 import requests
 import shutil
@@ -63,7 +65,7 @@ def command_exists(cmd):
 def main():
   """ Download cpplint.py and pylint.py and installs the git hooks"""
   script_directory = os.path.dirname(sys.argv[0])
-  script_directory = os.path.abspath(script_directory)
+  script_directory = os.path.dirname(os.path.abspath(script_directory))
 
   if cpplint_url != "":
     # Download linter files.
@@ -101,7 +103,7 @@ def main():
     exit(1)
 
   # Get git root folder of parent repository.
-  repo_root = get_git_repo_root(script_directory + '/../')
+  repo_root = get_git_repo_root('.')
 
   # Copy git hooks.
   cp_params = script_directory + "/git-hooks.py " + \

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -142,7 +142,6 @@ def main():
   arg_parser = argparse.ArgumentParser()
   arg_parser.add_argument(
       '--remove',
-      '-r',
       dest='remove_linter',
       action="store_true",
       help='Remove the linter from this repository.')

--- a/git-hooks.py
+++ b/git-hooks.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
+import os
 import subprocess
 import sys
 
@@ -22,10 +25,21 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
                                  some_folder_in_root_repo)
 
 
-def get_linter_subfolder(root_repo_folder):
-    """Find the subfolder where this linter is stored."""
-    return run_command_in_folder("git submodule | awk '{ print $2 }'" +
-                                 " | grep linter", root_repo_folder)
+def get_linter_folder(root_repo_folder):
+    """Find the folder where this linter is stored."""
+    linter_folder = run_command_in_folder(
+            "git submodule | awk '{ print $2 }'" + " | grep linter",
+            root_repo_folder)
+    if len(linter_folder) != 0:
+        return linter_folder
+
+    # Go via environment variable.
+    try:
+        return os.environ['LINTER_PATH']
+    except KeyError:
+        print("Cannot find linter because the environment variable "
+              "LINTER_PATH doesn't exist.")
+        sys.exit(1)
 
 
 def main():
@@ -33,15 +47,15 @@ def main():
     repo_root = get_git_repo_root()
 
     # Get linter subfolder
-    linter_subfolder = get_linter_subfolder(repo_root)
+    linter_folder = get_linter_folder(repo_root)
 
     # Append linter folder to the path so that we can import the linter module.
-    linter_folder = repo_root + "/" + linter_subfolder
+    linter_folder = os.path.join(repo_root, linter_folder)
     sys.path.append(linter_folder)
 
     import linter
 
-    linter.linter_check(repo_root, linter_subfolder)
+    linter.linter_check(repo_root, linter_folder)
 
 
 if __name__ == "__main__":

--- a/git_hooks.py
+++ b/git_hooks.py
@@ -27,13 +27,6 @@ def get_git_repo_root(some_folder_in_root_repo='./'):
 
 def get_linter_folder(root_repo_folder):
     """Find the folder where this linter is stored."""
-    linter_folder = run_command_in_folder(
-            "git submodule | awk '{ print $2 }'" + " | grep linter",
-            root_repo_folder)
-    if len(linter_folder) != 0:
-        return linter_folder
-
-    # Go via environment variable.
     try:
         return os.environ['LINTER_PATH']
     except KeyError:

--- a/git_hooks.py
+++ b/git_hooks.py
@@ -21,7 +21,6 @@ def run_command_in_folder(command, folder):
 
 def get_git_repo_root(some_folder_in_root_repo='./'):
     """Get the root folder of the current git repository."""
-    print('git folder to check:', some_folder_in_root_repo)
     return run_command_in_folder('git rev-parse --show-toplevel',
                                  some_folder_in_root_repo)
 

--- a/git_hooks.py
+++ b/git_hooks.py
@@ -21,6 +21,7 @@ def run_command_in_folder(command, folder):
 
 def get_git_repo_root(some_folder_in_root_repo='./'):
     """Get the root folder of the current git repository."""
+    print('git folder to check:', some_folder_in_root_repo)
     return run_command_in_folder('git rev-parse --show-toplevel',
                                  some_folder_in_root_repo)
 

--- a/linter.py
+++ b/linter.py
@@ -373,8 +373,8 @@ def linter_check(repo_root, linter_subfolder):
   ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
 
   # Read linter config file.
-  linter_config_file = repo_root + '/linterconfig.yaml'
-  if os.path.isfile(repo_root + '/linterconfig.yaml'):
+  linter_config_file = repo_root + '/.linterconfig.yaml'
+  if os.path.isfile(repo_root + '/.linterconfig.yaml'):
       print("Found repo linter config: {}".format(linter_config_file))
       linter_config = read_linter_config(linter_config_file)
   else:

--- a/linter.py
+++ b/linter.py
@@ -142,8 +142,8 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
           os.path.abspath(repo_root), os.path.abspath(package_root)])
       package_root = os.path.relpath(package_root, common_prefix)
 
-      # The package root needs to be relative to the repo root. Otherwise the
-      # header guard logic will fail!.
+      # The package root needs to be relative to the (top-level) repo root.
+      # Otherwise the header guard logic will fail!
       cpplint._root = package_root + '/include'   # pylint: disable=W0212
 
       # Reset error count and messages:
@@ -354,7 +354,7 @@ def get_whitelisted_files(repo_root, files, whitelist):
     for entry in whitelist:
       # Add trailing slash if its a directory and no slash is already there.
       if os.path.isdir(repo_root + '/' + entry):
-        entry = os.path.join(os.path.normpath(entry), '')
+          entry = os.path.join(os.path.normpath(entry), '')
 
       # Check if the file itself or its parent directory is in the whitelist.
       if (file == entry
@@ -375,10 +375,10 @@ def linter_check(repo_root, linter_subfolder):
   # Read linter config file.
   linter_config_file = repo_root + '/linterconfig.yaml'
   if os.path.isfile(repo_root + '/linterconfig.yaml'):
-    print("Found repo linter config: {}".format(linter_config_file))
-    linter_config = read_linter_config(linter_config_file)
+      print("Found repo linter config: {}".format(linter_config_file))
+      linter_config = read_linter_config(linter_config_file)
   else:
-    linter_config = DEFAULT_CONFIG
+      linter_config = DEFAULT_CONFIG
 
   print("Found linter subfolder: {}".format(linter_subfolder))
   print("Found ascii art file at: {}".format(ascii_art_file))
@@ -428,7 +428,7 @@ def linter_check(repo_root, linter_subfolder):
       cpp_lint_success = check_cpp_lint(
           whitelisted_files, cpplint_file, ascii_art, repo_root)
     else:
-      cpp_lint_success = True
+        cpp_lint_success = True
 
     # Use pylint to check for comimpliance with Tensofrflow python style guide.
     if linter_config['use_pylint']:

--- a/linter.py
+++ b/linter.py
@@ -124,6 +124,20 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
                                   "{}".format(changed_file))
 
       # Get relative path to repository root.
+      if os.path.isfile(os.path.join(repo_root, '.git')):
+        # Repo is a submodule, look for parent git repository containing this
+        # submodule.
+        search_path = repo_root
+        found_to_level_git_repo = False
+        for _ in range(10):
+          search_path = os.path.dirname(repo_root)
+          if os.path.isdir(os.path.join(search_path, '.git')):
+            found_to_level_git_repo = True
+            break
+
+        assert found_to_level_git_repo
+        repo_root = search_path
+
       common_prefix = os.path.commonprefix([
           os.path.abspath(repo_root), os.path.abspath(package_root)])
       package_root = os.path.relpath(package_root, common_prefix)
@@ -340,7 +354,7 @@ def get_whitelisted_files(repo_root, files, whitelist):
     for entry in whitelist:
       # Add trailing slash if its a directory and no slash is already there.
       if os.path.isdir(repo_root + '/' + entry):
-          entry = os.path.join(os.path.normpath(entry), '')
+        entry = os.path.join(os.path.normpath(entry), '')
 
       # Check if the file itself or its parent directory is in the whitelist.
       if (file == entry
@@ -361,10 +375,10 @@ def linter_check(repo_root, linter_subfolder):
   # Read linter config file.
   linter_config_file = repo_root + '/linterconfig.yaml'
   if os.path.isfile(repo_root + '/linterconfig.yaml'):
-      print("Found repo linter config: {}".format(linter_config_file))
-      linter_config = read_linter_config(linter_config_file)
+    print("Found repo linter config: {}".format(linter_config_file))
+    linter_config = read_linter_config(linter_config_file)
   else:
-      linter_config = DEFAULT_CONFIG
+    linter_config = DEFAULT_CONFIG
 
   print("Found linter subfolder: {}".format(linter_subfolder))
   print("Found ascii art file at: {}".format(ascii_art_file))
@@ -414,7 +428,7 @@ def linter_check(repo_root, linter_subfolder):
       cpp_lint_success = check_cpp_lint(
           whitelisted_files, cpplint_file, ascii_art, repo_root)
     else:
-        cpp_lint_success = True
+      cpp_lint_success = True
 
     # Use pylint to check for comimpliance with Tensofrflow python style guide.
     if linter_config['use_pylint']:

--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ YAPF_FORMAT_EXECUTABLE = "yapf"
 DEFAULT_CONFIG = {
   'use_clangformat':  True,
   'use_cpplint':      True,
-  # Disable Python checks by default.
+  # Enable Python checks by default.
   'use_yapf':         True,
   'use_pylint':       True,
   # Check all staged files by default.
@@ -123,6 +123,13 @@ def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
                                   "catkin package that contains: "
                                   "{}".format(changed_file))
 
+      # Get relative path to repository root.
+      common_prefix = os.path.commonprefix([
+          os.path.abspath(repo_root), os.path.abspath(package_root)])
+      package_root = os.path.relpath(package_root, common_prefix)
+
+      # The package root needs to be relative to the repo root. Otherwise the
+      # header guard logic will fail!.
       cpplint._root = package_root + '/include'   # pylint: disable=W0212
 
       # Reset error count and messages:
@@ -347,9 +354,9 @@ def get_whitelisted_files(repo_root, files, whitelist):
 def linter_check(repo_root, linter_subfolder):
   """ Main pre-commit function for calling code checking script. """
 
-  cpplint_file = repo_root + "/" + linter_subfolder + "/cpplint.py"
-  pylint_file = repo_root + "/" + linter_subfolder + "/pylint.rc"
-  ascii_art_file = repo_root + "/" + linter_subfolder + "/ascii_art.py"
+  cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
+  pylint_file = os.path.join(linter_subfolder, "pylint.rc")
+  ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
 
   # Read linter config file.
   linter_config_file = repo_root + '/linterconfig.yaml'

--- a/setup_linter.sh
+++ b/setup_linter.sh
@@ -1,0 +1,4 @@
+LINTER_PATH="$( cd "$( dirname "$0" )" && pwd )"
+export LINTER_PATH
+
+export PATH="$PATH:$LINTER_PATH/bin"

--- a/setup_linter.sh
+++ b/setup_linter.sh
@@ -1,4 +1,10 @@
-LINTER_PATH="$( cd "$( dirname "$0" )" && pwd )"
+if [ ! -z $ZSH_NAME ] ; then
+  LINTER_PATH="$( cd "$( dirname "$0" )" && pwd )"
+elif [ ! -z $BASH ] ; then
+  LINTER_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+else
+  echo "Linter: Unsupported shell! Only bash and zsh supported at the moment!"
+fi
 export LINTER_PATH
 
 export PATH="$PATH:$LINTER_PATH/bin"


### PR DESCRIPTION
New version of #22.

- Now you set an environment variable and add a script to the path. Then you can run this script and the linter is done.
- Adds support to install the linter in submodules.
- Possibility to remove the linter from the repo.

@mfehr @igilitschenski wdyt? This is not completely tested yet, but I wanted to get a second opinion first.

~~(The old submodule installation should still work, but it's no longer mentioned in the readme.)~~