### PR TITLE
Disabled more pylint warnings

### DIFF
--- a/default/pylint.rc
+++ b/default/pylint.rc
@@ -31,7 +31,7 @@ extension-pkg-whitelist=numpy
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time.
-disable=no-name-in-module,import-error,fixme,missing-docstring
+disable=no-name-in-module,import-error,fixme,missing-docstring,no-member,wrong-import-position
 
 
 [REPORTS]

--- a/default/pylint.rc
+++ b/default/pylint.rc
@@ -31,7 +31,7 @@ extension-pkg-whitelist=numpy
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time.
-disable=no-name-in-module,import-error,fixme,missing-docstring,no-member,wrong-import-position
+disable=no-name-in-module,import-error,fixme,missing-docstring,no-member,wrong-import-position,bad-continuation
 
 
 [REPORTS]


### PR DESCRIPTION
- `no-member`: I had a complaint that pylint couldn't find an import and I didn't want to fix the python setup to properly search for catkin python modules. Besides, similar warnings are already disabled for the same reason.

- `wrong-import-position`: pylint suggests really weird ordering. It wanted me to have system import (like `os`), then something from one of my modules before stuff like `numpy`.

- `bad-continuation`: I got these occasionally after a yapf formatting. Disabled because they seem to be impossible to fix without modifying yapf and I didn't want to invest time now.