### PR TITLE
Adapt to Ubuntu 18.04 / Apply linter to itself / Automatically search for clang-format version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # linter
 
-This repo contains a (C++, python (experimental)) linter and auto formatter package that can be included into your repository as a submodule. It provides the following git hooks:
+This repo contains a (C++, python) linter and auto formatter package that can be conveniently installed into your repositories using git hooks. It provides the following git hooks:
  * **General**
    * Prevent commits to master.
  * **C++** files:
-   * **clang-format** Formats your code based on your .clang-format preferences.
+ *
+   * **clang-format** Formats your code based on your `.clang-format` preferences.
    * **cpplint** Checks your C++ code for style errors and warnings.
 
  * **Python** files:
@@ -18,11 +19,11 @@ This repo contains a (C++, python (experimental)) linter and auto formatter pack
  * **yapf**
    * Ubuntu / macOS: `pip install yapf`
  * **clang-format**
-   * Ubuntu: `sudo apt install clang-format-3.8`
+   * Compatible with `clang-format-3.8 - 6.0`
+   * Ubuntu: `sudo apt install clang-format-${VERSION}`
    * macOS:
      ```
      brew install clang-format
-     ln -s /usr/local/share/clang/clang-format-diff.py /usr/local/bin/clang-format-diff-3.8
      ```
 
 
@@ -50,9 +51,14 @@ init_linter_git_hooks --remove
 ```
 
 ## Linter configuration
+
+**General**
+
 To configure the linter, add a file named `.linterconfig.yaml` in your repository root. An example file is given under [`linterconfig.yaml_example`](https://github.com/ethz-asl/linter/blob/master/linterconfig.yaml_example).
 
-Clang-format can be configured by defining a project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example file:
+**C++**
+
+clang-format can be configured by defining a project-specific C++ format by adding a file `.clang-format` to your projects root folder. Example file:
 
 ```
 ---
@@ -72,6 +78,10 @@ IncludeCategories:
     Priority:        2
 ...
 ```
+
+**Python**
+
+Currently there it is not possible to configure the python formatter on a per-repository basis.
 
 #### ASCII-Art Sources
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This repo contains a (C++, python) linter and auto formatter package that can be
 
 ## Dependencies
 
+ * **pylint**
+   * macOS:
+     ```
+     pip install pylint
+     ```
  * **yapf**
    * Ubuntu / macOS: `pip install yapf`
  * **clang-format**
@@ -24,6 +29,7 @@ This repo contains a (C++, python) linter and auto formatter package that can be
    * macOS:
      ```
      brew install clang-format
+     ln -s /usr/local/share/clang/clang-format-diff.py /usr/local/bin/clang-format-diff
      ```
 
 
@@ -34,8 +40,7 @@ git clone git@github.com:ethz-asl/linter.git
 cd linter
 echo ". $(realpath setup_linter.sh)" >> ~/.bashrc  # Or the matching file for
                                                    # your shell.
-source ~/.bashrc
-```
+source ~
 
 Then you can install the linter in your repository:
 ```bash
@@ -83,6 +88,41 @@ IncludeCategories:
 
 Currently there it is not possible to configure the python formatter on a per-repository basis.
 
-#### ASCII-Art Sources
+
+## Disable Linter Functionalities for a Specific Line
+
+ * **C++ Linter (`cpplint`):**
+   ```cpp
+   void your_awful_function(int & result) // NOLINT
+   ```
+ * **C++ Formatting (`clang-format`):**
+   ```cpp
+   // clang-format off
+   ...
+   // clang-format on   
+   ```
+ * **Python Linter (`pylint`)**
+
+   For whole file:
+   ```python
+   #!/usr/bin/env python
+   # pylint: disable=C0103,E1101
+   ...
+   ```
+   For a line:
+   ```Python
+   your_awful_function('-legal/copyright,-build/c++11')  # pylint: disable=W0212
+   ```
+   The full list of pylint warnings and errors can be found [here](http://pylint-messages.wikidot.com/all-messages)
+
+ * **Python Formatting (`yapf`)**
+   ```python
+   # yapf: disable
+   ...
+   # yapf: enable
+   ```
+
+
+## ASCII-Art Sources
 
  * [www.retrojunkie.com (accessed through web.archive.org)](https://web.archive.org/web/20150831003349/http://www.retrojunkie.com:80/asciiart/)

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -37,8 +37,8 @@ cpplint_url = ""
 clang_format_diff_executable = "clang-format-diff-6.0"
 
 CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
-    "clang-format-diff-6.0", "clang-format-diff-5.0", "clang-format-diff-4.0",
-    "clang-format-diff-3.9", "clang-format-diff-3.8"
+    "clang-format-diff", "clang-format-diff-6.0", "clang-format-diff-5.0",
+    "clang-format-diff-4.0", "clang-format-diff-3.9", "clang-format-diff-3.8"
 ]
 
 

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -34,8 +34,6 @@ default_cpplint = "modified_cpplint.py"
 
 cpplint_url = ""
 
-clang_format_diff_executable = "clang-format-diff-6.0"
-
 CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
     "clang-format-diff", "clang-format-diff-6.0", "clang-format-diff-5.0",
     "clang-format-diff-4.0", "clang-format-diff-3.9", "clang-format-diff-3.8"

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # Disable pylint filename and missing module member complaints.
 # pylint: disable=C0103,E1101
-
 """
 Initializes git hooks for the parent git repository.
 
@@ -24,10 +23,11 @@ from __future__ import print_function
 
 import argparse
 import os
-import requests
 import shutil
 import subprocess
 import sys
+
+import requests
 import yaml
 
 default_cpplint = "modified_cpplint.py"
@@ -36,122 +36,143 @@ cpplint_url = ""
 
 clang_format_diff_executable = "clang-format-diff-6.0"
 
+CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
+    "clang-format-diff-6.0", "clang-format-diff-5.0", "clang-format-diff-4.0",
+    "clang-format-diff-3.9", "clang-format-diff-3.8"
+]
+
 
 def download_file_from_url(url, file_path):
-  """Download a file from a HTTPS URL. Verification is enabled."""
-  request = requests.get(url, verify=True, stream=True)
-  request.raw.decode_content = True
-  with open(file_path, 'w') as downloaded_file:
-    shutil.copyfileobj(request.raw, downloaded_file)
+    """Download a file from a HTTPS URL. Verification is enabled."""
+    request = requests.get(url, verify=True, stream=True)
+    request.raw.decode_content = True
+    with open(file_path, 'w') as downloaded_file:
+        shutil.copyfileobj(request.raw, downloaded_file)
 
 
 def get_git_repo_root(some_folder_in_root_repo='./'):
-  """Get the root folder of the git repository."""
-  get_repo_call = subprocess.Popen("git rev-parse --show-toplevel",
-                                   shell=True,
-                                   cwd=some_folder_in_root_repo,
-                                   stdin=subprocess.PIPE,
-                                   stdout=subprocess.PIPE)
+    """Get the root folder of the git repository."""
+    get_repo_call = subprocess.Popen(
+        "git rev-parse --show-toplevel",
+        shell=True,
+        cwd=some_folder_in_root_repo,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE)
 
-  stdout, _ = get_repo_call.communicate()
-  repo_root = stdout.rstrip()
-  return repo_root
+    stdout, _ = get_repo_call.communicate()
+    repo_root = stdout.rstrip()
+    return repo_root
 
 
 def command_exists(cmd):
-  """Check if a bash command exists."""
-  return subprocess.call("type " + cmd, shell=True,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    """Check if a bash command exists."""
+    return subprocess.call(
+        "type " + cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE) == 0
+
+
+def find_clang_format_executable():
+    for executable in CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS:
+        if subprocess.call(
+                "type " + executable,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE) == 0:
+            return executable
+
+    print("ERROR: clang-format-diff is not installed!")
+    exit(1)
 
 
 def get_hooks_folder_for_repo():
-  # Get git root folder of parent repository.
-  repo_root = get_git_repo_root('.')
-  hooks_folder = os.path.join(repo_root, '.git/hooks')
-  if os.path.isfile(os.path.join(repo_root, '.git')):
-    # Git repo is a submodule, git information is in a folder listed in the .git
-    # file.
-    with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
-      git_folder = yaml.load(git_info_file)['gitdir']
-    repo_root = get_git_repo_root(os.path.join(repo_root, git_folder))
-    hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
-  return hooks_folder
+    # Get git root folder of parent repository.
+    repo_root = get_git_repo_root('.')
+    hooks_folder = os.path.join(repo_root, '.git/hooks')
+    if os.path.isfile(os.path.join(repo_root, '.git')):
+        # Git repo is a submodule, git information is in a folder listed in the .git
+        # file.
+        with open(os.path.join(repo_root, '.git'), 'r') as git_info_file:
+            git_folder = yaml.load(git_info_file)['gitdir']
+        repo_root = get_git_repo_root(os.path.join(repo_root, git_folder))
+        hooks_folder = os.path.join(repo_root, git_folder, 'hooks')
+    return hooks_folder
 
 
 def install_linter():
-  """ Download cpplint.py and pylint.py and installs the git hooks"""
-  script_directory = os.path.dirname(sys.argv[0])
-  script_directory = os.path.dirname(os.path.abspath(script_directory))
+    """ Download cpplint.py and pylint.py and installs the git hooks"""
+    script_directory = os.path.dirname(sys.argv[0])
+    script_directory = os.path.dirname(os.path.abspath(script_directory))
 
-  if cpplint_url != "":
-    # Download linter files.
-    download_file_from_url(cpplint_url, script_directory + "/cpplint.py")
-    if not os.path.isfile(script_directory + "/cpplint.py"):
-      print("ERROR: Could not download cpplint.py file!")
-      exit(1)
-  else:
-    cp_params = (script_directory + "/default/" + default_cpplint + " " +
-                 script_directory + "/cpplint.py")
+    if cpplint_url != "":
+        # Download linter files.
+        download_file_from_url(cpplint_url, script_directory + "/cpplint.py")
+        if not os.path.isfile(script_directory + "/cpplint.py"):
+            print("ERROR: Could not download cpplint.py file!")
+            exit(1)
+    else:
+        cp_params = (script_directory + "/default/" + default_cpplint + " " +
+                     script_directory + "/cpplint.py")
+        if subprocess.call("cp " + cp_params, shell=True) != 0:
+            print("Failed to copy default cpplint.")
+            exit(1)
+
+    default_pylint_file = os.path.join(script_directory, 'default',
+                                       'pylint.rc')
+    if not os.path.isfile(default_pylint_file):
+        print("Default pylint.rc wasn't found under", default_pylint_file)
+        exit(1)
+
+    cp_params = (default_pylint_file + " " + os.path.join(
+        script_directory, 'pylint.rc'))
     if subprocess.call("cp " + cp_params, shell=True) != 0:
-      print("Failed to copy default cpplint.")
-      exit(1)
+        print("Failed to copy default pylint.rc.")
+        exit(1)
 
-  default_pylint_file = os.path.join(script_directory, 'default', 'pylint.rc')
-  if not os.path.isfile(default_pylint_file):
-    print("Default pylint.rc wasn't found under", default_pylint_file)
-    exit(1)
+    if not os.path.isfile(script_directory + "/pylint.rc"):
+        print("ERROR: Could not download pylint.rc file!")
+        exit(1)
 
-  cp_params = (default_pylint_file + " " + os.path.join(script_directory, 'pylint.rc'))
-  if subprocess.call("cp " + cp_params, shell=True) != 0:
-    print("Failed to copy default pylint.rc.")
-    exit(1)
+    find_clang_format_executable()
 
-  if not os.path.isfile(script_directory + "/pylint.rc"):
-    print("ERROR: Could not download pylint.rc file!")
-    exit(1)
+    if not command_exists("yapf"):
+        print("ERROR: yapf is not installed! Try: pip install yapf")
+        exit(1)
 
-  if not command_exists(clang_format_diff_executable):
-    print("ERROR: " + clang_format_diff_executable + " is not installed!")
-    exit(1)
+    # Copy git hooks.
+    hooks_folder = get_hooks_folder_for_repo()
+    cp_params = script_directory + "/git_hooks.py " + \
+        hooks_folder + "/pre-commit"
+    if subprocess.call("cp " + cp_params, shell=True) != 0:
+        print("Failed to copy githooks to " "{}...".format(hooks_folder))
+        exit(1)
 
-  if not command_exists("yapf"):
-    print("ERROR: yapf is not installed! Try: pip install yapf")
-    exit(1)
-
-  # Copy git hooks.
-  hooks_folder = get_hooks_folder_for_repo()
-  cp_params = script_directory + "/git_hooks.py " + \
-      hooks_folder + "/pre-commit"
-  if subprocess.call("cp " + cp_params, shell=True) != 0:
-    print("Failed to copy githooks to "
-          "{}...".format(hooks_folder))
-    exit(1)
-
-  print("Success, githooks initialized!")
+    print("Success, githooks initialized!")
 
 
 def remove_linter():
-  hooks_folder = get_hooks_folder_for_repo()
-  pre_commit_file = os.path.join(hooks_folder, 'pre-commit')
-  with open(pre_commit_file, 'w+') as out_file:
-    out_file.write('#!/bin/sh\n')
-  print("Linter githooks removed!")
+    hooks_folder = get_hooks_folder_for_repo()
+    pre_commit_file = os.path.join(hooks_folder, 'pre-commit')
+    with open(pre_commit_file, 'w+') as out_file:
+        out_file.write('#!/bin/sh\n')
+    print("Linter githooks removed!")
 
 
 def main():
-  arg_parser = argparse.ArgumentParser()
-  arg_parser.add_argument(
-      '--remove',
-      dest='remove_linter',
-      action="store_true",
-      help='Remove the linter from this repository.')
-  args = arg_parser.parse_args()
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
+        '--remove',
+        dest='remove_linter',
+        action="store_true",
+        help='Remove the linter from this repository.')
+    args = arg_parser.parse_args()
 
-  if args.remove_linter:
-    remove_linter()
-  else:
-    install_linter()
+    if args.remove_linter:
+        remove_linter()
+    else:
+        install_linter()
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/bin/init_linter_git_hooks
+++ b/bin/init_linter_git_hooks
@@ -34,7 +34,7 @@ default_cpplint = "modified_cpplint.py"
 
 cpplint_url = ""
 
-clang_format_diff_executable = "clang-format-diff-3.8"
+clang_format_diff_executable = "clang-format-diff-6.0"
 
 
 def download_file_from_url(url, file_path):

--- a/linter.py
+++ b/linter.py
@@ -18,8 +18,8 @@ import pylint.lint
 import yaml
 
 CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
-    "clang-format-diff-6.0", "clang-format-diff-5.0", "clang-format-diff-4.0",
-    "clang-format-diff-3.9", "clang-format-diff-3.8"
+    "clang-format-diff", "clang-format-diff-6.0", "clang-format-diff-5.0",
+    "clang-format-diff-4.0", "clang-format-diff-3.9", "clang-format-diff-3.8"
 ]
 
 YAPF_FORMAT_EXECUTABLE = "yapf"

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ import re
 import subprocess
 import yaml
 
-CLANG_FORMAT_DIFF_EXECUTABLE = "clang-format-diff-3.8"
+CLANG_FORMAT_DIFF_EXECUTABLE = "clang-format-diff-6.0"
 YAPF_FORMAT_EXECUTABLE = "yapf"
 
 DEFAULT_CONFIG = {

--- a/linter.py
+++ b/linter.py
@@ -3,463 +3,490 @@
 
 # Disable pylint invalid module name complaint.
 # pylint : disable = C0103
-
 """ Pre-commit script for invoking linters and auto-formatters."""
 
 # Make sure we use the new print function
 from __future__ import print_function
-from random import randint
 
 import datetime
 import imp
 import os
-import pylint.lint
 import re
 import subprocess
+
+import pylint.lint
 import yaml
 
-CLANG_FORMAT_DIFF_EXECUTABLE = "clang-format-diff-6.0"
+CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
+    "clang-format-diff-6.0", "clang-format-diff-5.0", "clang-format-diff-4.0",
+    "clang-format-diff-3.9", "clang-format-diff-3.8"
+]
+
 YAPF_FORMAT_EXECUTABLE = "yapf"
 
 DEFAULT_CONFIG = {
-  'use_clangformat':  True,
-  'use_cpplint':      True,
-  # Enable Python checks by default.
-  'use_yapf':         True,
-  'use_pylint':       True,
-  # Check all staged files by default.
-  'whitelist':        []
+    'use_clangformat': True,
+    'use_cpplint': True,
+    # Enable Python checks by default.
+    'use_yapf': True,
+    'use_pylint': True,
+    # Check all staged files by default.
+    'whitelist': []
 }
 
 
 def read_linter_config(filename):
-  """Parses yaml config file."""
+    """Parses yaml config file."""
 
-  config = DEFAULT_CONFIG
-  with open(filename, 'r') as ymlfile:
-    parsed_config = yaml.load(ymlfile)
+    config = DEFAULT_CONFIG
+    with open(filename, 'r') as ymlfile:
+        parsed_config = yaml.load(ymlfile)
 
-  if 'clangformat' in parsed_config.keys():
-    config['use_clangformat'] = parsed_config['clangformat']
-  if 'cpplint' in parsed_config.keys():
-    config['use_cpplint'] = parsed_config['cpplint']
-  if 'yapf' in parsed_config.keys():
-    config['use_yapf'] = parsed_config['yapf']
-  if 'pylint' in parsed_config.keys():
-    config['use_pylint'] = parsed_config['pylint']
-  if 'whitelist' in parsed_config.keys():
-    config['whitelist'] = parsed_config['whitelist']
+    if 'clangformat' in parsed_config.keys():
+        config['use_clangformat'] = parsed_config['clangformat']
+    if 'cpplint' in parsed_config.keys():
+        config['use_cpplint'] = parsed_config['cpplint']
+    if 'yapf' in parsed_config.keys():
+        config['use_yapf'] = parsed_config['yapf']
+    if 'pylint' in parsed_config.keys():
+        config['use_pylint'] = parsed_config['pylint']
+    if 'whitelist' in parsed_config.keys():
+        config['whitelist'] = parsed_config['whitelist']
 
-  return config
+    return config
 
 
 def run_command_in_folder(command, folder):
-  """Run a bash command in a specific folder."""
-  run_command = subprocess.Popen(command,
-                                 shell=True,
-                                 cwd=folder,
-                                 stdin=subprocess.PIPE,
-                                 stdout=subprocess.PIPE)
-  stdout, _ = run_command.communicate()
-  command_output = stdout.rstrip()
-  return command_output
+    """Run a bash command in a specific folder."""
+    run_command = subprocess.Popen(
+        command,
+        shell=True,
+        cwd=folder,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE)
+    stdout, _ = run_command.communicate()
+    command_output = stdout.rstrip()
+    return command_output
 
 
 def get_number_of_commits(some_folder_in_root_repo='./'):
-  command = "git shortlog -s -n --all --author=\"$(git config --get user.email)\" | grep -o '[0-9]\+' |  awk '{s+=$1} END {print s}'"
-  num_commits = run_command_in_folder(command, some_folder_in_root_repo)
-  if not num_commits:
-    num_commits = "0"
-  return num_commits
+    command = (
+        "git shortlog -s -n --all --author=\"$(git config " +
+        "--get user.email)\" | grep -o '[0-9]\+' |  " +  # pylint: disable=W1401
+        "awk '{s+=$1} END {print s}'")
+    num_commits = run_command_in_folder(command, some_folder_in_root_repo)
+    if not num_commits:
+        num_commits = "0"
+    return num_commits
 
 
 def get_staged_files(some_folder_in_root_repo='./'):
-  """Get all staged files from git."""
-  output = run_command_in_folder(
-      "git diff --staged --name-only", some_folder_in_root_repo)
-  if len(output) == 0:
-    return []
-  else:
-    return output.split("\n")
+    """Get all staged files from git."""
+    output = run_command_in_folder("git diff --staged --name-only",
+                                   some_folder_in_root_repo)
+    if not output:
+        return []
+    else:
+        return output.split("\n")
 
 
 def get_unstaged_files(some_folder_in_root_repo='./'):
-  """Get all unstaged files from git."""
-  output = run_command_in_folder(
-      "git diff --name-only", some_folder_in_root_repo)
-  return output.split("\n")
+    """Get all unstaged files from git."""
+    output = run_command_in_folder("git diff --name-only",
+                                   some_folder_in_root_repo)
+    return output.split("\n")
 
 
 def check_cpp_lint(staged_files, cpplint_file, ascii_art, repo_root):
-  """Runs Google's cpplint on all C++ files staged for commit,"""
-  cpplint = imp.load_source('cpplint', cpplint_file)
-  cpplint._cpplint_state.SetFilters(
-      '-legal/copyright,-build/c++11')  # pylint: disable=W0212
+    """Runs Google's cpplint on all C++ files staged for commit,"""
+    cpplint = imp.load_source('cpplint', cpplint_file)
+    cpplint._cpplint_state.SetFilters('-legal/copyright,-build/c++11')  # pylint: disable=W0212
 
-  # Prevent cpplint from writing to stdout directly, instead
-  # the errors will be stored in pplint.output as (line, message) tuples.
-  cpplint.print_stdout = False
+    # Prevent cpplint from writing to stdout directly, instead
+    # the errors will be stored in pplint.output as (line, message) tuples.
+    cpplint.print_stdout = False
 
-  total_error_count = 0
-  for changed_file in staged_files:
-    if not os.path.isfile(changed_file):
-      continue
-    if changed_file.lower().endswith(('.cc', '.h', '.cpp', '.cu', '.cuh')):
-      # Search iteratively for the root of the catkin package.
-      package_root = ''
-      search_dir = os.path.dirname(os.path.abspath(changed_file))
-      found_package_root = False
-      MAX_DEPTH_OF_FILES = 100
-      for _ in range(1, MAX_DEPTH_OF_FILES):
-        if os.path.isfile(search_dir + '/package.xml'):
-          package_root = search_dir
-          found_package_root = True
-          break
-        # Stop if the root of the git repo is reached.
-        if os.path.isdir(search_dir + '/.git'):
-          break
-        search_dir = os.path.dirname(search_dir)
-      assert found_package_root, ("Could not find the root of the "
-                                  "catkin package that contains: "
-                                  "{}".format(changed_file))
+    total_error_count = 0
+    for changed_file in staged_files:
+        if not os.path.isfile(changed_file):
+            continue
+        if changed_file.lower().endswith(('.cc', '.h', '.cpp', '.cu', '.cuh')):
+            # Search iteratively for the root of the catkin package.
+            package_root = ''
+            search_dir = os.path.dirname(os.path.abspath(changed_file))
+            found_package_root = False
+            MAX_DEPTH_OF_FILES = 100
+            for _ in range(1, MAX_DEPTH_OF_FILES):
+                if os.path.isfile(search_dir + '/package.xml'):
+                    package_root = search_dir
+                    found_package_root = True
+                    break
+                # Stop if the root of the git repo is reached.
+                if os.path.isdir(search_dir + '/.git'):
+                    break
+                search_dir = os.path.dirname(search_dir)
+            assert found_package_root, ("Could not find the root of the "
+                                        "catkin package that contains: "
+                                        "{}".format(changed_file))
 
-      # Get relative path to repository root.
-      if os.path.isfile(os.path.join(repo_root, '.git')):
-        # Repo is a submodule, look for parent git repository containing this
-        # submodule.
-        search_path = repo_root
-        found_to_level_git_repo = False
-        for _ in range(10):
-          search_path = os.path.dirname(repo_root)
-          if os.path.isdir(os.path.join(search_path, '.git')):
-            found_to_level_git_repo = True
-            break
+            # Get relative path to repository root.
+            if os.path.isfile(os.path.join(repo_root, '.git')):
+                # Repo is a submodule, look for parent git repository containing
+                # this submodule.
+                search_path = repo_root
+                found_to_level_git_repo = False
+                for _ in range(10):
+                    search_path = os.path.dirname(repo_root)
+                    if os.path.isdir(os.path.join(search_path, '.git')):
+                        found_to_level_git_repo = True
+                        break
 
-        assert found_to_level_git_repo
-        repo_root = search_path
+                assert found_to_level_git_repo
+                repo_root = search_path
 
-      common_prefix = os.path.commonprefix([
-          os.path.abspath(repo_root), os.path.abspath(package_root)])
-      package_root = os.path.relpath(package_root, common_prefix)
+            common_prefix = os.path.commonprefix(
+                [os.path.abspath(repo_root),
+                 os.path.abspath(package_root)])
+            package_root = os.path.relpath(package_root, common_prefix)
 
-      # The package root needs to be relative to the (top-level) repo root.
-      # Otherwise the header guard logic will fail!
-      cpplint._root = package_root + '/include'   # pylint: disable=W0212
+            # The package root needs to be relative to the (top-level) repo
+            # root. Otherwise the header guard logic will fail!
+            cpplint._root = package_root + '/include'  # pylint: disable=W0212
 
-      # Reset error count and messages:
-      cpplint.output = []
-      cpplint._cpplint_state.ResetErrorCounts()   # pylint: disable=W0212
-      v_level = cpplint._cpplint_state.verbose_level  # pylint: disable=W0212
+            # Reset error count and messages:
+            cpplint.output = []
+            cpplint._cpplint_state.ResetErrorCounts()  # pylint: disable=W0212
+            v_level = cpplint._cpplint_state.verbose_level  # pylint: disable=W0212
 
-      cpplint.ProcessFile(changed_file, v_level)
+            cpplint.ProcessFile(changed_file, v_level)
 
-      error_count = cpplint._cpplint_state.error_count  # pylint: disable=W0212
-      if error_count > 0:
-        total_error_count += error_count
+            error_count = cpplint._cpplint_state.error_count  # pylint: disable=W0212
+            if error_count > 0:
+                total_error_count += error_count
 
-        print("-" * 80)
-        print("Found {} errors in : {}".format(
-            error_count, changed_file))
-        print("-" * 80)
-        for line in cpplint.output:
-          assert len(line) == 2
-          print("line {: >4}:\t {}".format(line[0], line[1]))
+                print("-" * 80)
+                print("Found {} errors in : {}".format(error_count,
+                                                       changed_file))
+                print("-" * 80)
+                for line in cpplint.output:
+                    assert len(line) == 2
+                    print("line {: >4}:\t {}".format(line[0], line[1]))
 
-  if total_error_count > 0:
-    print("=" * 80)
-    print("Found {} cpplint errors".format(total_error_count))
-    print("=" * 80)
+    if total_error_count > 0:
+        print("=" * 80)
+        print("Found {} cpplint errors".format(total_error_count))
+        print("=" * 80)
 
-    if total_error_count > 50:
-      print(ascii_art.AsciiArt.cthulhu)
-    elif total_error_count > 20:
-      print(ascii_art.AsciiArt.tiger)
-    return False
-  else:
-    return True
+        if total_error_count > 50:
+            print(ascii_art.AsciiArt.cthulhu)
+        elif total_error_count > 20:
+            print(ascii_art.AsciiArt.tiger)
+        return False
+    else:
+        return True
 
 
 def check_modified_after_staging(staged_files):
-  """Checks if one of the staged files was modified after staging."""
-  files_changed = get_unstaged_files()
-  files_changed = filter(None, files_changed)  # pylint: disable=W0141
+    """Checks if one of the staged files was modified after staging."""
+    files_changed = get_unstaged_files()
+    files_changed = filter(None, files_changed)
 
-  staged_files_changed = 0
+    staged_files_changed = 0
 
-  staged_files_changed_list = []
+    staged_files_changed_list = []
 
-  is_first = True
-  for changed_file in files_changed:
-    if changed_file in staged_files:
+    is_first = True
+    for changed_file in files_changed:
+        if changed_file in staged_files:
 
-      if is_first:
+            if is_first:
+                print("=" * 80)
+                is_first = False
+
+            print("\'{}\' was modified after staging".format(changed_file))
+            staged_files_changed_list.append(changed_file)
+            staged_files_changed += 1
+
+    if staged_files_changed > 0:
+        print("-" * 80)
+        print("Found {} files that have been changed after staging".format(
+            staged_files_changed))
         print("=" * 80)
-        is_first = False
 
-      print("\'{}\' was modified after staging".format(changed_file))
-      staged_files_changed_list.append(changed_file)
-      staged_files_changed += 1
-
-  if staged_files_changed > 0:
-    print("-" * 80)
-    print("Found {} files that have been changed after staging".format(
-        staged_files_changed))
-    print("=" * 80)
-
-  return staged_files_changed_list
+    return staged_files_changed_list
 
 
 def check_commit_against_master(repo_root):
-  """Check if the current commit is intended to for the master branch."""
-  current_branch = run_command_in_folder(
-      "git branch | grep \"*\" | sed \"s/* //\"", repo_root)
-  print("\nCurrent_branch: {}\n".format(current_branch))
-  return current_branch == "master"
+    """Check if the current commit is intended to for the master branch."""
+    current_branch = run_command_in_folder(
+        "git branch | grep \"*\" | sed \"s/* //\"", repo_root)
+    print("\nCurrent_branch: {}\n".format(current_branch))
+    return current_branch == "master"
 
 
 def check_if_merge_commit(repo_root):
-  """Check if the current commit is a merge commit."""
-  merge_msg_file_path = repo_root + "/.git/MERGE_MSG"
-  return os.path.isfile(merge_msg_file_path)
+    """Check if the current commit is a merge commit."""
+    merge_msg_file_path = repo_root + "/.git/MERGE_MSG"
+    return os.path.isfile(merge_msg_file_path)
+
+
+def find_clang_format_executable():
+    for executable in CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS:
+        if subprocess.call(
+                "type " + executable,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE) == 0:
+            return executable
+
+    print("ERROR: clang-format-diff is not installed!")
+    exit(1)
 
 
 def run_clang_format(repo_root, staged_files, list_of_changed_staged_files):
-  """Runs clang format on all cpp files staged for commit."""
+    """Runs clang format on all cpp files staged for commit."""
 
-  clang_format_path = ("/tmp/" + os.path.basename(
-      os.path.normpath(repo_root)) + "_" +
-      datetime.datetime.now().isoformat() + ".clang.patch")
+    clang_format_path = (
+        "/tmp/" + os.path.basename(os.path.normpath(repo_root)) + "_" +
+        datetime.datetime.now().isoformat() + ".clang.patch")
 
-  run_command_in_folder("git diff -U0 --cached | " +
-                        CLANG_FORMAT_DIFF_EXECUTABLE +
-                        " -style=file -p1 > " +
-                        clang_format_path, repo_root)
+    clang_format_diff_executable = find_clang_format_executable()
 
-  if not os.stat(clang_format_path).st_size == 0:
-    if list_of_changed_staged_files:
-      print("=" * 80)
-      print("Cannot format your code, because some files are \n"
-            "only partially staged! Format your code or try \n"
-            "stashing your unstaged changes...")
-      print("=" * 80)
-      exit(1)
+    run_command_in_folder(
+        "git diff -U0 --cached | " + clang_format_diff_executable +
+        " -style=file -p1 > " + clang_format_path, repo_root)
 
-    run_command_in_folder("git apply -p0 " + clang_format_path, repo_root)
-    run_command_in_folder("git add " + ' '.join(staged_files), repo_root)
+    if not os.stat(clang_format_path).st_size == 0:
+        if list_of_changed_staged_files:
+            print("=" * 80)
+            print("Cannot format your code, because some files are \n"
+                  "only partially staged! Format your code or try \n"
+                  "stashing your unstaged changes...")
+            print("=" * 80)
+            exit(1)
 
-    print("=" * 80)
-    print("Formatted staged C++ files with clang-format.\n" +
-          "Patch: {}".format(clang_format_path))
-    print("=" * 80)
-  return True
+        run_command_in_folder("git apply -p0 " + clang_format_path, repo_root)
+        run_command_in_folder("git add " + ' '.join(staged_files), repo_root)
 
-
-def run_yapf_format(repo_root, staged_files, list_of_changed_staged_files):
-  """Runs yapf format on all python files staged for commit."""
-
-  first_file_formatted = True
-  for staged_file in staged_files:
-    if not os.path.isfile(staged_file):
-      continue
-    if staged_file.endswith((".py")):
-
-      # Check if the file needs formatting by applying the formatting and store
-      # the results into a patch file.
-      yapf_format_path = ("/tmp/" +
-                              os.path.basename(os.path.normpath(repo_root)) +
-                              "_" + datetime.datetime.now().isoformat() +
-                              ".yapf.patch")
-      task = (YAPF_FORMAT_EXECUTABLE + " --style pep8 -d " + staged_file +
-              " > " + yapf_format_path)
-      run_command_in_folder(task, repo_root)
-
-      if not os.stat(yapf_format_path).st_size == 0:
-        if first_file_formatted:
-          print("=" * 80)
-          print("Formatted staged python files with autopep8:")
-          first_file_formatted = False
-
-        print("-> " + staged_file)
-
-        if staged_file in list_of_changed_staged_files:
-          print("Cannot format your code, because this file is \n"
-                "only partially staged! Format your code or try \n"
-                "stashing your unstaged changes...")
-          print("=" * 80)
-          exit(1)
-        else:
-          run_command_in_folder(
-              "git apply -p0 " + yapf_format_path, repo_root)
-          run_command_in_folder("git add " + staged_file, repo_root)
-
-  if not first_file_formatted:
-    print("=" * 80)
-  return True
-
-
-def check_python_lint(repo_root, staged_files, pylint_file):
-  """Runs pylint on all python scripts staged for commit."""
-
-  class TextReporterBuffer(object):
-    """Stores the output produced by the pylint TextReporter."""
-
-    def __init__(self):
-      """init"""
-      self.content = []
-
-    def write(self, input_str):
-      """write"""
-      self.content.append(input_str)
-
-    def read(self):
-      """read"""
-      return self.content
-
-  # Parse each pylint output line individualy and searches
-  # for errors in the code.
-  pylint_errors = []
-  for changed_file in staged_files:
-    if not os.path.isfile(changed_file):
-      continue
-    if re.search(r'\.py$', changed_file):
-
-      print("Running pylint on \'{}\'".format(repo_root + "/" + changed_file))
-      pylint_output = TextReporterBuffer()
-      pylint_args = ["--rcfile=" + pylint_file,
-                     "-rn",
-                     repo_root + "/" + changed_file]
-      from pylint.reporters.text import TextReporter
-      pylint.lint.Run(pylint_args,
-                      reporter=TextReporter(pylint_output),
-                      exit=False)
-
-      for output_line in pylint_output.read():
-        if re.search(r'^(E|C|W):', output_line):
-          print(changed_file + ": " + output_line)
-          pylint_errors.append(output_line)
-
-  if len(pylint_errors) > 0:
-    print("=" * 80)
-    print("Found {} pylint errors".format(len(pylint_errors)))
-    print("=" * 80)
-    return False
-  else:
+        print("=" * 80)
+        print("Formatted staged C++ files with clang-format.\n" +
+              "Patch: {}".format(clang_format_path))
+        print("=" * 80)
     return True
 
 
+def run_yapf_format(repo_root, staged_files, list_of_changed_staged_files):
+    """Runs yapf format on all python files staged for commit."""
+
+    first_file_formatted = True
+    for staged_file in staged_files:
+        if not os.path.isfile(staged_file):
+            continue
+        if staged_file.endswith((".py")):
+
+            # Check if the file needs formatting by applying the formatting and
+            # store the results into a patch file.
+            yapf_format_path = (
+                "/tmp/" + os.path.basename(os.path.normpath(repo_root)) + "_" +
+                datetime.datetime.now().isoformat() + ".yapf.patch")
+            task = (YAPF_FORMAT_EXECUTABLE + " --style pep8 -d " + staged_file
+                    + " > " + yapf_format_path)
+            run_command_in_folder(task, repo_root)
+
+            if not os.stat(yapf_format_path).st_size == 0:
+                if first_file_formatted:
+                    print("=" * 80)
+                    print("Formatted staged python files with autopep8:")
+                    first_file_formatted = False
+
+                print("-> " + staged_file)
+
+                if staged_file in list_of_changed_staged_files:
+                    print("Cannot format your code, because this file is \n"
+                          "only partially staged! Format your code or try \n"
+                          "stashing your unstaged changes...")
+                    print("=" * 80)
+                    exit(1)
+                else:
+                    run_command_in_folder("git apply -p0 " + yapf_format_path,
+                                          repo_root)
+                    run_command_in_folder("git add " + staged_file, repo_root)
+
+    if not first_file_formatted:
+        print("=" * 80)
+    return True
+
+
+def check_python_lint(repo_root, staged_files, pylint_file):
+    """Runs pylint on all python scripts staged for commit."""
+
+    class TextReporterBuffer(object):
+        """Stores the output produced by the pylint TextReporter."""
+
+        def __init__(self):
+            """init"""
+            self.content = []
+
+        def write(self, input_str):
+            """write"""
+            self.content.append(input_str)
+
+        def read(self):
+            """read"""
+            return self.content
+
+    # Parse each pylint output line individualy and searches
+    # for errors in the code.
+    pylint_errors = []
+    for changed_file in staged_files:
+        if not os.path.isfile(changed_file):
+            continue
+        if re.search(r'\.py$', changed_file):
+
+            print("Running pylint on \'{}\'".format(repo_root + "/" +
+                                                    changed_file))
+            pylint_output = TextReporterBuffer()
+            pylint_args = [
+                "--rcfile=" + pylint_file, "-rn",
+                repo_root + "/" + changed_file
+            ]
+            from pylint.reporters.text import TextReporter
+            pylint.lint.Run(
+                pylint_args, reporter=TextReporter(pylint_output), exit=False)
+
+            for output_line in pylint_output.read():
+                if re.search(r'^(E|C|W):', output_line):
+                    print(changed_file + ": " + output_line)
+                    pylint_errors.append(output_line)
+
+    if pylint_errors:
+        print("=" * 80)
+        print("Found {} pylint errors".format(len(pylint_errors)))
+        print("=" * 80)
+        return False
+    else:
+        return True
+
+
 def get_whitelisted_files(repo_root, files, whitelist):
-  whitelisted = [];
+    whitelisted = []
 
-  for file in files:
-    for entry in whitelist:
-      # Add trailing slash if its a directory and no slash is already there.
-      if os.path.isdir(repo_root + '/' + entry):
-          entry = os.path.join(os.path.normpath(entry), '')
+    for file_name in files:
+        for entry in whitelist:
+            # Add trailing slash if its a directory and no slash is already
+            # there.
+            if os.path.isdir(repo_root + '/' + entry):
+                entry = os.path.join(os.path.normpath(entry), '')
 
-      # Check if the file itself or its parent directory is in the whitelist.
-      if (file == entry
-          or os.path.commonprefix([file, entry]) == entry):
-        whitelisted.append(file)
-        break
+            # Check if the file itself or its parent directory is in the
+            # whitelist.
+            if (file_name == entry
+                    or os.path.commonprefix([file_name, entry]) == entry):
+                whitelisted.append(file_name)
+                break
 
-  return whitelisted
+    return whitelisted
 
 
 def linter_check(repo_root, linter_subfolder):
-  """ Main pre-commit function for calling code checking script. """
+    """ Main pre-commit function for calling code checking script. """
 
-  cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
-  pylint_file = os.path.join(linter_subfolder, "pylint.rc")
-  ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
+    cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
+    pylint_file = os.path.join(linter_subfolder, "pylint.rc")
+    ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
 
-  # Read linter config file.
-  linter_config_file = repo_root + '/.linterconfig.yaml'
-  if os.path.isfile(repo_root + '/.linterconfig.yaml'):
-      print("Found repo linter config: {}".format(linter_config_file))
-      linter_config = read_linter_config(linter_config_file)
-  else:
-      linter_config = DEFAULT_CONFIG
-
-  print("Found linter subfolder: {}".format(linter_subfolder))
-  print("Found ascii art file at: {}".format(ascii_art_file))
-  print("Found cpplint file at: {}".format(cpplint_file))
-  print("Found pylint file at: {}".format(pylint_file))
-
-  # Run checks
-  staged_files = get_staged_files()
-
-  if len(staged_files) == 0:
-    print("\n")
-    print("=" * 80)
-    print("No files staged...")
-    print("=" * 80)
-    exit(1)
-
-  if len(linter_config['whitelist']) > 0:
-    whitelisted_files = get_whitelisted_files(repo_root, staged_files,
-                                              linter_config['whitelist'])
-  else:
-    whitelisted_files = staged_files
-
-  # Load ascii art.
-  ascii_art = imp.load_source('ascii_art', ascii_art_file)
-
-  if check_commit_against_master(repo_root):
-    print(ascii_art.AsciiArt.grumpy_cat)
-    exit(1)
-
-  if not check_if_merge_commit(repo_root):
-    # Do not allow commiting files that were modified after staging. This
-    # avoids problems such as forgetting to stage fixes of cpplint complaints.
-    list_of_changed_staged_files = check_modified_after_staging(
-      whitelisted_files)
-
-    if linter_config['use_clangformat']:
-      run_clang_format(repo_root, whitelisted_files,
-                       list_of_changed_staged_files)
-
-    if linter_config['use_yapf']:
-      run_yapf_format(repo_root, whitelisted_files,
-                          list_of_changed_staged_files)
-
-
-    # Use Google's C++ linter to check for compliance with Google style guide.
-    if linter_config['use_cpplint']:
-      cpp_lint_success = check_cpp_lint(
-          whitelisted_files, cpplint_file, ascii_art, repo_root)
+    # Read linter config file.
+    linter_config_file = repo_root + '/.linterconfig.yaml'
+    if os.path.isfile(repo_root + '/.linterconfig.yaml'):
+        print("Found repo linter config: {}".format(linter_config_file))
+        linter_config = read_linter_config(linter_config_file)
     else:
-        cpp_lint_success = True
+        linter_config = DEFAULT_CONFIG
 
-    # Use pylint to check for comimpliance with Tensofrflow python style guide.
-    if linter_config['use_pylint']:
-      pylint_success = check_python_lint(repo_root, whitelisted_files, pylint_file)
+    print("Found linter subfolder: {}".format(linter_subfolder))
+    print("Found ascii art file at: {}".format(ascii_art_file))
+    print("Found cpplint file at: {}".format(cpplint_file))
+    print("Found pylint file at: {}".format(pylint_file))
+
+    # Run checks
+    staged_files = get_staged_files()
+
+    if not staged_files:
+        print("\n")
+        print("=" * 80)
+        print("No files staged...")
+        print("=" * 80)
+        exit(1)
+
+    if linter_config['whitelist']:
+        whitelisted_files = get_whitelisted_files(repo_root, staged_files,
+                                                  linter_config['whitelist'])
     else:
-      pylint_success = True
+        whitelisted_files = staged_files
 
-    if not(cpp_lint_success and pylint_success):
-      print("=" * 80)
-      print("Commit rejected! Please address the linter errors above.")
-      print("=" * 80)
-      exit(1)
+    # Load ascii art.
+    ascii_art = imp.load_source('ascii_art', ascii_art_file)
+
+    if check_commit_against_master(repo_root):
+        print(ascii_art.AsciiArt.grumpy_cat)
+        exit(1)
+
+    if not check_if_merge_commit(repo_root):
+        # Do not allow commiting files that were modified after staging. This
+        # avoids problems such as forgetting to stage fixes of cpplint
+        # complaints.
+        list_of_changed_staged_files = check_modified_after_staging(
+            whitelisted_files)
+
+        if linter_config['use_clangformat']:
+            run_clang_format(repo_root, whitelisted_files,
+                             list_of_changed_staged_files)
+
+        if linter_config['use_yapf']:
+            run_yapf_format(repo_root, whitelisted_files,
+                            list_of_changed_staged_files)
+
+        # Use Google's C++ linter to check for compliance with Google style
+        # guide.
+        if linter_config['use_cpplint']:
+            cpp_lint_success = check_cpp_lint(whitelisted_files, cpplint_file,
+                                              ascii_art, repo_root)
+        else:
+            cpp_lint_success = True
+
+        # Use pylint to check for comimpliance with Tensofrflow python
+        # style guide.
+        if linter_config['use_pylint']:
+            pylint_success = check_python_lint(repo_root, whitelisted_files,
+                                               pylint_file)
+        else:
+            pylint_success = True
+
+        if not (cpp_lint_success and pylint_success):
+            print("=" * 80)
+            print("Commit rejected! Please address the linter errors above.")
+            print("=" * 80)
+            exit(1)
+        else:
+
+            commit_number = get_number_of_commits(repo_root)
+            lucky_commit = ((int(commit_number) + 1) % 42 == 0)
+
+            if lucky_commit:
+                print(ascii_art.AsciiArt.story)
+
+                print("=" * 80)
+                print("Commit accepted, well done! This is your {}th commit!".
+                      format(commit_number))
+                print("This is a lucky commit! " +
+                      "Please enjoy this free sheep story.")
+                print("=" * 80)
+            else:
+                print(ascii_art.AsciiArt.commit_success)
+
+                print("=" * 80)
+                print("Commit accepted, well done! This is the {}th commit!".
+                      format(commit_number))
+                print("=" * 80)
     else:
-
-      commit_number = get_number_of_commits(repo_root)
-      lucky_commit = ((int(commit_number) + 1) % 42 == 0)
-
-      if lucky_commit:
-        print(ascii_art.AsciiArt.story)
-
-        print("=" * 80)
-        print("Commit accepted, well done! This is your {}th commit!".format(
-            commit_number))
-        print("This is a lucky commit! Please enjoy this free sheep story.")
-        print("=" * 80)
-      else:
-        print(ascii_art.AsciiArt.commit_success)
-
-        print("=" * 80)
-        print("Commit accepted, well done! This is the {}th commit!".format(
-            commit_number))
-        print("=" * 80)
-  else:
-    print(ascii_art.AsciiArt.homer_woohoo)
+        print(ascii_art.AsciiArt.homer_woohoo)


### PR DESCRIPTION
Changes
 * Adapted to Ubuntu 18.04 by automatically search for the correct clang-format executable
 * Apply linter to itself, fix lots of linter errors
 * Add README section about how to disable linter functions from inside code

I added a comment to all real changes to distinguish them from the changes caused by the formatting.

~~@eggerk can you please test this on 16.04?~~ Tested, thanks!
~~@igilitschenski if you still run OSX, could you give this a try?~~ Tested by @ntonci, thanks!