### PR TITLE
Configurable pylint.rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ IncludeCategories:
 
 **Python**
 
-Currently there it is not possible to configure the python formatter on a per-repository basis.
+Currently there it is not possible to configure the python formatter on a per-repository basis. The linter can be configured on a per-repository bais by adding a `.pylintrc` file to your repositorie's root folder.
+
 
 
 ## Disable Linter Functionalities for a Specific Line

--- a/linter.py
+++ b/linter.py
@@ -27,13 +27,15 @@ CLANG_FORMAT_DIFF_EXECUTABLE_VERSIONS = [
 YAPF_FORMAT_EXECUTABLE = "yapf"
 
 DEFAULT_CONFIG = {
+    # Enable code checks and formatting by default.
     'use_clangformat': True,
     'use_cpplint': True,
-    # Enable Python checks by default.
     'use_yapf': True,
     'use_pylint': True,
+    # Use the config files of the linter by default.
+    'pylint_config': 'global',
     # Block commits that don't pass by default
-    'block-commits': True,
+    'block_commits': True,
     # Check all staged files by default.
     'whitelist': []
 }
@@ -71,8 +73,10 @@ def read_linter_config(filename):
         config['use_yapf'] = parsed_config['yapf']
     if 'pylint' in parsed_config.keys():
         config['use_pylint'] = parsed_config['pylint']
-    if 'block-commits' in parsed_config.keys():
-        config['block-commits'] = parsed_config['block-commits']
+    if 'pylint_config' in parsed_config.keys():
+        config['pylint_config'] = parsed_config['pylint_config']
+    if 'block_commits' in parsed_config.keys():
+        config['block_commits'] = parsed_config['block_commits']
     if 'whitelist' in parsed_config.keys():
         config['whitelist'] = parsed_config['whitelist']
 
@@ -414,10 +418,6 @@ def get_whitelisted_files(repo_root, files, whitelist):
 def linter_check(repo_root, linter_subfolder):
     """ Main pre-commit function for calling code checking script. """
 
-    cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
-    pylint_file = os.path.join(linter_subfolder, "pylint.rc")
-    ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
-
     # Read linter config file.
     linter_config_file = repo_root + '/.linterconfig.yaml'
     if os.path.isfile(repo_root + '/.linterconfig.yaml'):
@@ -426,10 +426,27 @@ def linter_check(repo_root, linter_subfolder):
     else:
         linter_config = DEFAULT_CONFIG
 
+
+    cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
+    ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
+
+    if linter_config['pylint_config'] == "global":
+        pylintrc_file = os.path.join(linter_subfolder, "pylint.rc")
+    elif linter_config['pylint_config'] == "local":
+        if not os.path.isfile(os.path.join(repo_root, ".pylintrc")):
+            print("A .pylintrc file is required in the repository root")
+            exit(1)
+        pylintrc_file = os.path.join(repo_root, ".pylintrc")
+    else:
+        print("{} is not a valid setting for pylint_config".format(
+            linter_config['pylint_config']))
+        exit(1)
+
+
     print("Found linter subfolder: {}".format(linter_subfolder))
     print("Found ascii art file at: {}".format(ascii_art_file))
     print("Found cpplint file at: {}".format(cpplint_file))
-    print("Found pylint file at: {}".format(pylint_file))
+    print("Found pylint config file at: {}".format(pylintrc_file))
 
     # Run checks
     staged_files = get_staged_files()
@@ -481,7 +498,7 @@ def linter_check(repo_root, linter_subfolder):
         # style guide.
         if linter_config['use_pylint']:
             pylint_success = check_python_lint(repo_root, whitelisted_files,
-                                               pylint_file)
+                                               pylintrc_file)
         else:
             pylint_success = True
 
@@ -490,7 +507,7 @@ def linter_check(repo_root, linter_subfolder):
             print("Commit not up to standards!")
             print("Please address the linter errors above.")
             print("=" * 80)
-            if linter_config['block-commits']:
+            if linter_config['block_commits']:
                 exit(1)
 
             else:

--- a/linter.py
+++ b/linter.py
@@ -32,8 +32,6 @@ DEFAULT_CONFIG = {
     'use_cpplint': True,
     'use_yapf': True,
     'use_pylint': True,
-    # Use the config files of the linter by default.
-    'pylint_config': 'global',
     # Block commits that don't pass by default
     'block_commits': True,
     # Check all staged files by default.
@@ -73,8 +71,6 @@ def read_linter_config(filename):
         config['use_yapf'] = parsed_config['yapf']
     if 'pylint' in parsed_config.keys():
         config['use_pylint'] = parsed_config['pylint']
-    if 'pylint_config' in parsed_config.keys():
-        config['pylint_config'] = parsed_config['pylint_config']
     if 'block_commits' in parsed_config.keys():
         config['block_commits'] = parsed_config['block_commits']
     if 'whitelist' in parsed_config.keys():
@@ -430,17 +426,10 @@ def linter_check(repo_root, linter_subfolder):
     cpplint_file = os.path.join(linter_subfolder, "cpplint.py")
     ascii_art_file = os.path.join(linter_subfolder, "ascii_art.py")
 
-    if linter_config['pylint_config'] == "global":
-        pylintrc_file = os.path.join(linter_subfolder, "pylint.rc")
-    elif linter_config['pylint_config'] == "local":
-        if not os.path.isfile(os.path.join(repo_root, ".pylintrc")):
-            print("A .pylintrc file is required in the repository root")
-            exit(1)
+    if os.path.isfile(os.path.join(repo_root, ".pylintrc")):
         pylintrc_file = os.path.join(repo_root, ".pylintrc")
     else:
-        print("{} is not a valid setting for pylint_config".format(
-            linter_config['pylint_config']))
-        exit(1)
+        pylintrc_file = os.path.join(linter_subfolder, "pylint.rc")
 
 
     print("Found linter subfolder: {}".format(linter_subfolder))

--- a/linterconfig.yaml_example
+++ b/linterconfig.yaml_example
@@ -3,7 +3,15 @@ clangformat: on
 cpplint: on
 yapf: on
 pylint: on
-block-commits: on
+
+# If set to global, the linter uses the pylint.rc from the "default" folder. If
+# set to local, the linter uses .pylintrc from the repository root.
+pylint_config: global
+
+# If on, the linter blocks commits after detecting an error. Otherwise, the
+# user is asked whether to proceed
+# with the commit.
+block_commits: on
 
 # If this whitelist block is present, the linter only operates on the files and
 # directories listed in this whitelist.

--- a/linterconfig.yaml_example
+++ b/linterconfig.yaml_example
@@ -4,13 +4,8 @@ cpplint: on
 yapf: on
 pylint: on
 
-# If set to global, the linter uses the pylint.rc from the "default" folder. If
-# set to local, the linter uses .pylintrc from the repository root.
-pylint_config: global
-
 # If on, the linter blocks commits after detecting an error. Otherwise, the
-# user is asked whether to proceed
-# with the commit.
+# user is asked whether to proceed with the commit.
 block_commits: on
 
 # If this whitelist block is present, the linter only operates on the files and


### PR DESCRIPTION
This PR makes pylintrc configurable in the sense that it also allows for repository specific pylint configuration. If you are okay with it, I will be happy to add the same functionality to the three other tools later as well. For now, we only required it for pylintrc.