### PR TITLE
Add Missing Dependency To ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ This repo contains a (C++, python) linter and auto formatter package that can be
      brew install clang-format
      ln -s /usr/local/share/clang/clang-format-diff.py /usr/local/bin/clang-format-diff
      ```
-
+ * **requests**
+   * Ubuntu:
+     ```
+     pip install requests
+     ``` 
 
 ## Installation
 


### PR DESCRIPTION
## General
Just noticed that `requests` is missing from the install instructions (as also noted here #34). 
I quickly added it to the README:
![image](https://user-images.githubusercontent.com/1336474/177550379-fa93d903-f32d-416f-9570-94f7863b1f9e.png)
